### PR TITLE
Added Toast.jsx

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,8 @@
     "react-multi-carousel": "^2.8.5",
     "react-router-dom": "^6.23.1",
     "react-slick": "^0.30.2",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "react-hot-toast": "^2.4.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/frontend/src/Components/common/Toast.jsx
+++ b/frontend/src/Components/common/Toast.jsx
@@ -1,0 +1,36 @@
+import { toast } from 'react-hot-toast';
+
+// import { Toaster } from 'react-hot-toast';                 // In element where it is being included
+// Implement using showLoadingToast(ApiCallPromise , deafultMessages)
+
+//defaultMessages = {
+//   loading: 'Saving...',
+//   success: 'Settings saved successfully!',
+//   error: 'Could not save settings.',
+// }
+
+// In API call, use Promise with resolve and reject
+
+// For success : resolve({message : })
+// For failure : reject({message : })
+
+//Include Toaster element using <Toaster />
+
+export const showLoadingToast = (promise, defaultMessages) => {
+  return toast.promise(
+    promise,
+    {
+      loading: defaultMessages.loading,
+      success: (data) => <b>{data.message || defaultMessages.success}</b>,
+      error: (error) => <b>{error.message || defaultMessages.error}</b>,
+    },
+    {
+      position: 'top-center',
+      style: {
+        background: 'white',
+        color: 'black',
+      },
+    }
+  );
+};
+


### PR DESCRIPTION
Created Toast.jsx using react-hot-toast
It will give a toast for loading and change to sucess or failure.
Function in Toast.jsx can be used with a promise on API call. Message has to be specified in API call using resolve or reject.

Implementation has been specified in comments of Toast.jsx


https://github.com/Curious-Ecosystem/Curious-Connect/assets/125668554/ce2944e8-2b20-47e0-bb28-85e911082806

